### PR TITLE
Resolves Issue #9, related to mule packaging

### DIFF
--- a/plugins/mule-app-maven-plugin/src/main/java/org/mule/tools/maven/plugin/app/MuleMojo.java
+++ b/plugins/mule-app-maven-plugin/src/main/java/org/mule/tools/maven/plugin/app/MuleMojo.java
@@ -10,19 +10,17 @@
 
 package org.mule.tools.maven.plugin.app;
 
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.mule.tools.artifact.archiver.api.MuleApplicationArchiveBuilder;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
-
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.MavenProjectHelper;
-import org.codehaus.plexus.archiver.ArchiverException;
-import org.codehaus.plexus.archiver.jar.JarArchiver;
 
 /**
  * Build a Mule application archive.
@@ -34,11 +32,6 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 public class MuleMojo extends AbstractMuleMojo
 {
     public final static String LIB_LOCATION = "lib" + File.separator;
-
-    /**
-     * @component
-     */
-    private MavenProjectHelper projectHelper;
 
     /**
      * Directory containing the classes.
@@ -101,7 +94,7 @@ public class MuleMojo extends AbstractMuleMojo
             throw new MojoExecutionException("Exception creating the Mule App", e);
         }
 
-        this.projectHelper.attachArtifact(this.project, "zip", app);
+        this.project.getArtifact().setFile(app);
     }
 
     protected void createMuleApp(final File app) throws MojoExecutionException, ArchiverException

--- a/plugins/mule-app-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/plugins/mule-app-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -56,6 +56,7 @@
             <configuration>
                 <type>mule</type>
                 <language>java</language>
+                <extension>zip</extension>
                 <addedToClasspath>true</addedToClasspath>
             </configuration>
         </component>


### PR DESCRIPTION
Resolves (and implements the suggestions) from #9 
- Set the generated app file as the primary artifact of the Build.
- Set the extension type for 'mule' packaging, so that other plugins which interrogate ArtifactHandlers for packaging types can determine the proper file extension.

Tested this locally with several mulesoft builds. It also improves things by addressing the source of the log messages about missing primary artifacts when maven-install-plugin and maven-deploy-plugin execute.
