### PR TITLE
Updated app maven plugin to publish generated JAR as a Maven artifact…

### DIFF
--- a/plugins/mule-app-maven-plugin/src/main/java/org/mule/tools/maven/plugin/app/MuleMojo.java
+++ b/plugins/mule-app-maven-plugin/src/main/java/org/mule/tools/maven/plugin/app/MuleMojo.java
@@ -65,7 +65,6 @@ public class MuleMojo extends AbstractMuleMojo
     /**
      * List of exclusion elements (having groupId and artifactId children) to exclude from the
      * application archive.
-     *
      * @parameter
      * @since 1.2
      */
@@ -228,7 +227,11 @@ public class MuleMojo extends AbstractMuleMojo
         }
         else
         {
-            addArchivedClasses(muleApplicationArchiveBuilder);
+            File jar = addArchivedClasses(muleApplicationArchiveBuilder);
+            if(jar != null)
+            {
+            	this.projectHelper.attachArtifact(this.project, "jar", jar);
+            }
         }
     }
 
@@ -258,12 +261,12 @@ public class MuleMojo extends AbstractMuleMojo
         }
     }
 
-    private void addArchivedClasses(MuleApplicationArchiveBuilder muleApplicationArchiveBuilder) throws ArchiverException, MojoExecutionException
+    private File addArchivedClasses(MuleApplicationArchiveBuilder muleApplicationArchiveBuilder) throws ArchiverException, MojoExecutionException
     {
         if (!this.classesDirectory.exists())
         {
             getLog().info(this.classesDirectory + " does not exist, skipping");
-            return;
+            return null;
         }
 
         getLog().info("Copying classes as a jar");
@@ -283,6 +286,8 @@ public class MuleMojo extends AbstractMuleMojo
             getLog().error(message, e);
             throw new MojoExecutionException(message, e);
         }
+		
+		return jar;
     }
 
     private void addDependencies(MuleApplicationArchiveBuilder muleApplicationArchiveBuilder) throws ArchiverException


### PR DESCRIPTION
When creating a Maven project and using mule packaging, we have the option to generate a jar file containing the classes etc as well as creating the normal Mule .zip file (by setting `<archiveClasses>true</archiveClasses>` within the `mule-app-maven-plugin` configuration). 

This change publishes that Jar file as a Maven artifact (instead of only publishing the Zip) so that it can be easily used as a dependency to other Maven projects with its classes etc available at compile time.

Note that this is currently desirable as Maven does not currently add Zip dependencies to the classpath of projects as it should, according to the Java spec. This will be fixed in a future Maven version (see [MNG-5567](https://issues.apache.org/jira/browse/MNG-5567)) but this is a simple workaround for the meantime.